### PR TITLE
Rename test.py to app.py and update tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,7 +157,7 @@ class StreamingProgress:
 class SmartCache:
     def __init__(self, cache_dir="data/cache"):
         self.cache_dir = Path(cache_dir)
-        self.cache_dir.mkdir(exist_ok=True)
+        self.cache_dir.mkdir(exist_ok=True, parents=True)
         self.memory_cache = {}
         self.cache_stats = {"hits": 0, "misses": 0}
     

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,7 +1,7 @@
 import types
 import sys
 
-# Stub out heavy modules before importing test.py
+# Stub out heavy modules before importing app.py
 st = types.ModuleType('streamlit')
 st.session_state = types.SimpleNamespace(settings={})
 sys.modules['streamlit'] = st
@@ -22,7 +22,7 @@ import importlib.util
 from pathlib import Path
 
 spec = importlib.util.spec_from_file_location(
-    "project_test", Path(__file__).resolve().parents[1] / "test.py"
+    "project_test", Path(__file__).resolve().parents[1] / "app.py"
 )
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,14 +2,12 @@ import sys
 from types import ModuleType
 from unittest.mock import MagicMock
 
-# Mock external dependencies required when importing test.py
+# Mock external dependencies required when importing app.py
 missing_modules = [
     'streamlit',
     'PyPDF2',
     'docx',
     'ollama',
-    'pandas',
-    'numpy',
     'plotly',
     'plotly.graph_objects',
     'plotly.express',
@@ -30,7 +28,6 @@ sys.modules['plotly'].express = MagicMock()
 sys.modules['transformers'].AutoTokenizer = MagicMock()
 sys.modules['transformers'].AutoModelForCausalLM = MagicMock()
 sys.modules['docx'].Document = MagicMock()
-sys.modules['pandas'].DataFrame = MagicMock()
 # Provide torch.classes.__path__ for compatibility
 class _Classes:
     __path__ = []
@@ -43,7 +40,7 @@ from pathlib import Path
 
 spec = importlib.util.spec_from_file_location(
     "app_module",
-    Path(__file__).resolve().parents[1] / "test.py",
+    Path(__file__).resolve().parents[1] / "app.py",
 )
 test = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(test)


### PR DESCRIPTION
## Summary
- rename `test.py` to `app.py`
- create cache directory parents on init
- update tests to import `app.py`
- remove pandas mocking in `test_validator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876f922935c832da4af375d21bde968